### PR TITLE
Omitting the expression syntax in `if` conditionals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,5 @@ jobs:
         if: ${{ !startsWith(github.head_ref, 'pione30/') }}
         run: echo "Explicitly github.head_ref does NOT startsWith 'pione30/'"
       - name: Not operator on the head without the expression syntax
-        if: !startsWith(github.head_ref, 'pione30/')
-        run: echo "github.head_ref does NOT startsWith 'pione30/' (??)"
+        if: (!startsWith(github.head_ref, 'pione30/'))
+        run: echo "github.head_ref does NOT startsWith 'pione30/'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
         if: (!startsWith(github.head_ref, 'pione30/'))
         run: echo "github.head_ref does NOT startsWith 'pione30/'"
 
-      - name: Verbatim Tags (1)
-        if: !<tag:yaml.org,2002:str> startsWith(github.head_ref, 'pione30/')
-        run: echo "github.head_ref DOES startsWith 'pione30/'"
-      - name: Verbatim Tags (2)
-        if: !<tag:yaml.org,2002:str> startsWith(github.head_ref, 'foobar/')
-        run: echo "github.head_ref DOES startsWith 'pione30/'"
+      - name: Not always
+        if: !!str !always()
+        run: echo "This line will not be exectued"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,10 @@ jobs:
       - name: Expression syntax omitted
         if: github.actor == 'pione30'
         run: echo "github.actor is pione30 even though the expression syntax omitted"
+
+      - name: Not operator on the head in the explicit expression syntax
+        if: ${{ !startsWith(github.head_ref, 'pione30/') }}
+        run: echo "Explicitly github.head_ref does NOT startsWith 'pione30/'"
+      - name: Not operator on the head without the expression syntax
+        if: !startsWith(github.head_ref, 'pione30/')
+        run: echo "github.head_ref does NOT startsWith 'pione30/' (??)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,6 @@ jobs:
         if: (!startsWith(github.head_ref, 'pione30/'))
         run: echo "github.head_ref does NOT startsWith 'pione30/'"
 
-      - name: Not always
-        if: !!str !always()
-        run: echo "This line will not be exectued"
+      - name: Correct tag handle
+        if: !!str always()
+        run: echo "This line will be exectued"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,3 @@ jobs:
       - name: Not operator on the head without the expression syntax
         if: (!startsWith(github.head_ref, 'pione30/'))
         run: echo "github.head_ref does NOT startsWith 'pione30/'"
-
-      - name: Correct tag handle
-        if: !!str always()
-        run: echo "This line will be exectued"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,10 @@ jobs:
       - name: Not operator on the head without the expression syntax
         if: (!startsWith(github.head_ref, 'pione30/'))
         run: echo "github.head_ref does NOT startsWith 'pione30/'"
+
+      - name: Verbatim Tags (1)
+        if: !<tag:yaml.org,2002:str> startsWith(github.head_ref, 'pione30/')
+        run: echo "github.head_ref DOES startsWith 'pione30/'"
+      - name: Verbatim Tags (2)
+        if: !<tag:yaml.org,2002:str> startsWith(github.head_ref, 'foobar/')
+        run: echo "github.head_ref DOES startsWith 'pione30/'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,3 +6,14 @@ on:
       - opened
       - reopened
       - synchronize
+
+jobs:
+  if-omit-expression-syntax-test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Explicit expression syntax
+        if: ${{ github.actor == 'pione30' }}
+        run: echo "Explicitly github.actor is pione30"
+      - name: Expression syntax omitted
+        if: github.actor == 'pione30'
+        run: echo "github.actor is pione30 even though the expression syntax omitted"


### PR DESCRIPTION
> When you use expressions in an `if` conditional, you may omit the expression syntax (`${{ }}`) because GitHub automatically evaluates the `if` conditional as an expression. 
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions